### PR TITLE
feat: support key-value tag attributes for structured metadata parsing

### DIFF
--- a/plugin-robot/src/main/java/com/epam/reportportal/extension/robot/service/RobotReportTag.java
+++ b/plugin-robot/src/main/java/com/epam/reportportal/extension/robot/service/RobotReportTag.java
@@ -30,6 +30,7 @@ public enum RobotReportTag {
   DOC("doc"),
   ARG("arg"),
   TAG("tag"),
+  ATTR_KEY("key"),
   ATTR_LIBRARY("library"),
   ATTR_NAME("name"),
   ATTR_LINE("line"),

--- a/plugin-robot/src/main/java/com/epam/reportportal/extension/robot/service/RobotXmlParser.java
+++ b/plugin-robot/src/main/java/com/epam/reportportal/extension/robot/service/RobotXmlParser.java
@@ -2,6 +2,7 @@ package com.epam.reportportal.extension.robot.service;
 
 import static com.epam.reportportal.extension.robot.service.AbstractImportStrategy.cleanMessage;
 import static com.epam.reportportal.extension.robot.service.RobotReportTag.ARG;
+import static com.epam.reportportal.extension.robot.service.RobotReportTag.ATTR_KEY;
 import static com.epam.reportportal.extension.robot.service.RobotReportTag.ATTR_ELAPSED;
 import static com.epam.reportportal.extension.robot.service.RobotReportTag.ATTR_END_TIME;
 import static com.epam.reportportal.extension.robot.service.RobotReportTag.ATTR_GENERATED;
@@ -356,7 +357,16 @@ public class RobotXmlParser {
   private void updateWithTags(Element element, ItemInfo itemInfo) {
     List<Node> tags = findChildNodes(element, TAG.val());
     Set<ItemAttributesRQ> attributes = tags.stream()
-        .map(it -> new ItemAttributesRQ(it.getTextContent())).collect(Collectors.toSet());
+        .map(node -> {
+          Element tagElement = (Element) node;
+          String key = tagElement.getAttribute(ATTR_KEY.val()).trim();
+          String value = tagElement.getTextContent().trim();
+          if (StringUtils.hasText(key)) {
+            return new ItemAttributesRQ(key, value);
+          }
+          return new ItemAttributesRQ(value);
+        })
+        .collect(Collectors.toSet());
     itemInfo.setItemAttributes(attributes);
   }
 

--- a/plugin-robot/src/main/java/com/epam/reportportal/extension/robot/service/RobotXmlParser.java
+++ b/plugin-robot/src/main/java/com/epam/reportportal/extension/robot/service/RobotXmlParser.java
@@ -361,11 +361,15 @@ public class RobotXmlParser {
           Element tagElement = (Element) node;
           String key = tagElement.getAttribute(ATTR_KEY.val()).trim();
           String value = tagElement.getTextContent().trim();
+          if (!StringUtils.hasText(value)) {
+            return null;
+          }
           if (StringUtils.hasText(key)) {
             return new ItemAttributesRQ(key, value);
           }
           return new ItemAttributesRQ(value);
         })
+        .filter(Objects::nonNull)
         .collect(Collectors.toSet());
     itemInfo.setItemAttributes(attributes);
   }

--- a/plugin-robot/src/test/java/com/epam/reportportal/extension/robot/service/RobotXmlParserTest.java
+++ b/plugin-robot/src/test/java/com/epam/reportportal/extension/robot/service/RobotXmlParserTest.java
@@ -104,4 +104,22 @@ class RobotXmlParserTest {
         .collect(Collectors.toSet());
     assertEquals(Set.of("scenario_owner:team-trust", "component:authentication"), values);
   }
+
+  @Test
+  void blankValueTagsAreSkipped() throws IOException {
+    List<StartTestItemRQ> started = captureStartItemEvents();
+
+    RobotXmlParser parser = new RobotXmlParser(eventPublisher, "launch-uuid", "project", false);
+    parser.parse(xml("report_with_blank_value_tags.xml"));
+
+    StartTestItemRQ testItem = started.stream()
+        .filter(rq -> "Login Test".equals(rq.getName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Test item not found"));
+
+    Set<ItemAttributesRQ> attributes = testItem.getAttributes();
+    // blank-valued tags should be dropped; only the valid tag remains
+    assertEquals(1, attributes.size());
+    assertEquals("team-test", attributes.iterator().next().getValue());
+  }
 }

--- a/plugin-robot/src/test/java/com/epam/reportportal/extension/robot/service/RobotXmlParserTest.java
+++ b/plugin-robot/src/test/java/com/epam/reportportal/extension/robot/service/RobotXmlParserTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 EPAM Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.epam.reportportal.extension.robot.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+import com.epam.reportportal.base.infrastructure.events.StartChildItemRqEvent;
+import com.epam.reportportal.base.reporting.ItemAttributesRQ;
+import com.epam.reportportal.base.reporting.StartTestItemRQ;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class RobotXmlParserTest {
+
+  @Mock
+  ApplicationEventPublisher eventPublisher;
+
+  private List<StartTestItemRQ> captureStartItemEvents() {
+    List<StartTestItemRQ> captured = new ArrayList<>();
+    doAnswer(invocation -> {
+      Object event = invocation.getArgument(0);
+      if (event instanceof StartChildItemRqEvent e) {
+        captured.add(e.getStartTestItemRq());
+      }
+      return null;
+    }).when(eventPublisher).publishEvent(any());
+    return captured;
+  }
+
+  private InputStream xml(String resourceName) {
+    return getClass().getClassLoader().getResourceAsStream(resourceName);
+  }
+
+  @Test
+  void keyValueTagsAreParsedAsKeyValueAttributes() throws IOException {
+    List<StartTestItemRQ> started = captureStartItemEvents();
+
+    RobotXmlParser parser = new RobotXmlParser(eventPublisher, "launch-uuid", "project", false);
+    parser.parse(xml("report_with_key_value_tags.xml"));
+
+    StartTestItemRQ testItem = started.stream()
+        .filter(rq -> "Login Test".equals(rq.getName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Test item not found"));
+
+    Set<ItemAttributesRQ> attributes = testItem.getAttributes();
+    assertEquals(2, attributes.size());
+
+    Map<String, String> attrMap = attributes.stream()
+        .collect(Collectors.toMap(ItemAttributesRQ::getKey, ItemAttributesRQ::getValue, (a, b) -> a));
+
+    assertEquals("team-trust", attrMap.get("scenario_owner"));
+    assertEquals("authentication", attrMap.get("component"));
+  }
+
+  @Test
+  void plainTagsAreBackwardCompatible() throws IOException {
+    List<StartTestItemRQ> started = captureStartItemEvents();
+
+    RobotXmlParser parser = new RobotXmlParser(eventPublisher, "launch-uuid", "project", false);
+    parser.parse(xml("report_with_plain_tags.xml"));
+
+    StartTestItemRQ testItem = started.stream()
+        .filter(rq -> "Login Test".equals(rq.getName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Test item not found"));
+
+    Set<ItemAttributesRQ> attributes = testItem.getAttributes();
+    assertEquals(2, attributes.size());
+
+    // plain tags have no key — value is the full text content
+    attributes.forEach(attr -> assertNull(attr.getKey()));
+
+    Set<String> values = attributes.stream()
+        .map(ItemAttributesRQ::getValue)
+        .collect(Collectors.toSet());
+    assertEquals(Set.of("scenario_owner:team-trust", "component:authentication"), values);
+  }
+}

--- a/plugin-robot/src/test/resources/report_with_blank_value_tags.xml
+++ b/plugin-robot/src/test/resources/report_with_blank_value_tags.xml
@@ -1,0 +1,11 @@
+<robot generator="Swift XML generator" generated="20240101 10:00:00.000">
+  <suite id="s1" name="Acceptance Tests" source="/AcceptanceTests.swift">
+    <test id="s1-t1" name="Login Test" line="10">
+      <tag key="scenario_owner">team-test</tag>
+      <tag key="component"></tag>
+      <tag></tag>
+      <status status="PASS" start="2024-01-01T10:00:00" elapsed="1.5"/>
+    </test>
+    <status status="PASS" start="2024-01-01T10:00:00" elapsed="1.5"/>
+  </suite>
+</robot>

--- a/plugin-robot/src/test/resources/report_with_key_value_tags.xml
+++ b/plugin-robot/src/test/resources/report_with_key_value_tags.xml
@@ -1,0 +1,10 @@
+<robot generator="Swift XML generator" generated="20240101 10:00:00.000">
+  <suite id="s1" name="Acceptance Tests" source="/AcceptanceTests.swift">
+    <test id="s1-t1" name="Login Test" line="10">
+      <tag key="scenario_owner">team-trust</tag>
+      <tag key="component">authentication</tag>
+      <status status="PASS" start="2024-01-01T10:00:00" elapsed="1.5"/>
+    </test>
+    <status status="PASS" start="2024-01-01T10:00:00" elapsed="1.5"/>
+  </suite>
+</robot>

--- a/plugin-robot/src/test/resources/report_with_plain_tags.xml
+++ b/plugin-robot/src/test/resources/report_with_plain_tags.xml
@@ -1,0 +1,10 @@
+<robot generator="Swift XML generator" generated="20240101 10:00:00.000">
+  <suite id="s1" name="Acceptance Tests" source="/AcceptanceTests.swift">
+    <test id="s1-t1" name="Login Test" line="10">
+      <tag>scenario_owner:team-trust</tag>
+      <tag>component:authentication</tag>
+      <status status="PASS" start="2024-01-01T10:00:00" elapsed="1.5"/>
+    </test>
+    <status status="PASS" start="2024-01-01T10:00:00" elapsed="1.5"/>
+  </suite>
+</robot>


### PR DESCRIPTION
## Problem

The current `<tag>` parsing in `RobotXmlParser` reads the entire text content as a single value, making it impossible to represent structured metadata as separate key and value fields in ReportPortal. Tools consuming the ReportPortal API (e.g. Backstage) expect attributes with distinct keys and values, but receive a concatenated string like `scenario_owner:team-name` as a single value with no key.

## Solution

Extended `updateWithTags` to read an optional `key` XML attribute on `<tag>` elements. When present, the tag is parsed into a proper key-value `ItemAttributesRQ`. When absent, the existing behaviour is preserved — the full text content becomes the value with a null key — so all existing XML files continue to work without any changes.

Tags with blank or whitespace-only values are now filtered out to prevent invalid attributes from being created.

```xml
<!-- new format — parsed as key="scenario_owner", value="team-name" -->
<tag key="scenario_owner">team-name</tag>

<!-- existing format — unchanged behaviour, value="scenario_owner:team-name" -->
<tag>scenario_owner:team-name</tag>

<!-- blank values are skipped -->
<tag key="component"></tag>
<tag></tag>
```

## Changes

- `RobotReportTag` — added `ATTR_KEY("key")` constant
- `RobotXmlParser` — updated `updateWithTags` to:
  - Read the `key` attribute and construct `ItemAttributesRQ(key, value)` when present
  - Fall back to `ItemAttributesRQ(value)` for plain tags
  - Filter out tags with empty or whitespace-only values
- `RobotXmlParserTest` — three new tests covering key-value tags, plain tags, and blank value filtering
- Test fixtures — `report_with_key_value_tags.xml`, `report_with_plain_tags.xml`, and `report_with_blank_value_tags.xml`

## Testing

- All existing and new unit tests pass
- Verified end-to-end on a ReportPortal instance:
  - XML with the existing plain tag format (`<tag>key:value</tag>`) imports correctly with no regression
  - XML with the new key attribute format (`<tag key="...">value</tag>`) imports correctly with separate key and value fields visible in the UI
  - XML with blank value tags correctly skips invalid entries

## Backward compatibility

No breaking changes. XML files without the `key` attribute are handled identically to before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Robot report tag handling now supports tags with explicit key/value pairs, improving how test metadata is captured.
  * Plain tag text continues to be supported, preserving compatibility with existing reports.

* **Bug Fixes**
  * Test attributes are now parsed more accurately from Robot XML reports, including both structured and plain tag formats.
  * Tags with blank values are now filtered out to prevent invalid attributes.

* **Tests**
  * Added coverage for both key/value tags and legacy plain tags to prevent regressions.
  * Added test for blank value filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->